### PR TITLE
Fix nix-index-database module path and simplify TypeScript packages

### DIFF
--- a/config/home-manager.nix
+++ b/config/home-manager.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ./bash.nix
-    inputs.nix-index-database.hmModules.nix-index
+    inputs.nix-index-database.homeModules.nix-index
   ];
 
   programs.nix-index-database.comma.enable = true;
@@ -21,8 +21,8 @@
     openssl             # OpenSSL is a robust, full-featured open-source toolkit
     pre-commit          # Framework for managing and maintaining multi-language pre-commit hooks
     trufflehog          # Scans git repositories for secrets
-    nodePackages.typescript              # TypeScript compiler
-    nodePackages.typescript-language-server  # TypeScript/JavaScript LSP
+    typescript              # TypeScript compiler
+    typescript-language-server  # TypeScript/JavaScript LSP
     wget                # A network utility to retrieve files from the Web
     yq-go               # Command-line YAML processor
   ];


### PR DESCRIPTION
## Summary
This PR updates the home-manager configuration to fix a module import path and simplifies TypeScript package references by using top-level packages instead of the nodePackages namespace.

## Key Changes
- Fixed `nix-index-database` module import: changed `hmModules` to `homeModules` to match the correct attribute path in the flake input
- Simplified TypeScript package references:
  - Changed `nodePackages.typescript` to `typescript`
  - Changed `nodePackages.typescript-language-server` to `typescript-language-server`

## Details
The nix-index-database flake exports its home-manager module under `homeModules` rather than `hmModules`. The TypeScript packages are now referenced directly from nixpkgs rather than through the nodePackages namespace, which is cleaner and more maintainable.

https://claude.ai/code/session_01B1KKbv3vHAhuaPmAXZ8Prn