### PR TITLE
Replace discontinued wslu with wslview shim in WSL config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,11 +47,17 @@
                 # Include the base WSL module path
                 nixos-wsl.nixosModules.default
                 # Include the specific WSL settings as a separate module element
-                ({ pkgs, ... }: { 
+                ({ pkgs, ... }: {
                   wsl.enable = true;
                   wsl.defaultUser = "ken";
                   # Add other WSL specific options here if needed
-                  environment.systemPackages = with pkgs; [ wslu ];
+                  # wslu was discontinued upstream; provide a minimal wslview shim
+                  # that opens URLs/files via Windows interop.
+                  environment.systemPackages = [
+                    (pkgs.writeShellScriptBin "wslview" ''
+                      exec cmd.exe /c start "$@" 2>/dev/null
+                    '')
+                  ];
                 })
               ]
             else


### PR DESCRIPTION
## Summary
Replaces the discontinued `wslu` package with a minimal `wslview` shell script shim that provides URL/file opening functionality via Windows interop in the WSL NixOS configuration.

## Changes
- Removed dependency on `wslu` package (which is no longer maintained upstream)
- Implemented a lightweight `wslview` command using `writeShellScriptBin` that delegates to Windows' `cmd.exe start` command
- Added explanatory comments documenting the rationale for the change
- Fixed trailing whitespace in the module definition

## Implementation Details
The new `wslview` shim:
- Uses `cmd.exe /c start` to open URLs and files through Windows interop
- Suppresses stderr output (`2>/dev/null`) to avoid noise from Windows processes
- Maintains compatibility with existing scripts that may call `wslview`
- Provides a minimal but functional replacement for the core use case of opening resources in the Windows environment

https://claude.ai/code/session_01L6yiR6ZX8eYcmjjsvSC4pu